### PR TITLE
Transition to contextualized `Done` state on setup error

### DIFF
--- a/src/agent/onefuzz-supervisor/src/agent.rs
+++ b/src/agent/onefuzz-supervisor/src/agent.rs
@@ -143,6 +143,7 @@ impl Agent {
         let scheduler = match state.finish(self.setup_runner.as_mut()).await? {
             SetupDone::Ready(s) => s.into(),
             SetupDone::PendingReboot(s) => s.into(),
+            SetupDone::Done(s) => s.into(),
         };
 
         Ok(scheduler)

--- a/src/agent/onefuzz-supervisor/src/coordinator.rs
+++ b/src/agent/onefuzz-supervisor/src/coordinator.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 
 use crate::auth::AccessToken;
 use crate::config::Registration;
+use crate::process::Output;
 use crate::work::{TaskId, WorkSet};
 use crate::worker::WorkerEvent;
 
@@ -58,6 +59,11 @@ pub struct NodeEventEnvelope {
 pub enum NodeEvent {
     StateUpdate { state: NodeState },
     WorkerEvent { event: WorkerEvent },
+    Done {
+        state: NodeState,
+        error: Option<String>,
+        script_output: Option<Output>,
+    }
 }
 
 impl From<NodeState> for NodeEvent {

--- a/src/agent/onefuzz-supervisor/src/coordinator/double.rs
+++ b/src/agent/onefuzz-supervisor/src/coordinator/double.rs
@@ -20,7 +20,7 @@ impl ICoordinator for CoordinatorDouble {
         Ok(())
     }
 
-    async fn can_schedule(&mut self, work: &WorkSet) -> Result<bool> {
+    async fn can_schedule(&mut self, _work: &WorkSet) -> Result<bool> {
         Ok(true)
     }
 }

--- a/src/agent/onefuzz-supervisor/src/debug.rs
+++ b/src/agent/onefuzz-supervisor/src/debug.rs
@@ -9,6 +9,7 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::coordinator::*;
+use crate::process::*;
 use crate::work::*;
 use crate::worker::*;
 

--- a/src/agent/onefuzz-supervisor/src/main.rs
+++ b/src/agent/onefuzz-supervisor/src/main.rs
@@ -22,6 +22,7 @@ pub mod auth;
 pub mod config;
 pub mod coordinator;
 pub mod debug;
+pub mod process;
 pub mod reboot;
 pub mod scheduler;
 pub mod setup;

--- a/src/agent/onefuzz-supervisor/src/process.rs
+++ b/src/agent/onefuzz-supervisor/src/process.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/// Serializable representation of a process output.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Output {
+    pub exit_status: ExitStatus,
+    pub stderr: String,
+    pub stdout: String,
+}
+
+impl From<std::process::Output> for Output {
+    fn from(output: std::process::Output) -> Self {
+        let exit_status = output.status.into();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+
+        Self {
+            exit_status,
+            stderr,
+            stdout,
+        }
+    }
+}
+
+/// Serializable representation of a process exit status.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ExitStatus {
+    pub code: Option<i32>,
+    pub signal: Option<i32>,
+    pub success: bool,
+}
+
+impl From<std::process::ExitStatus> for ExitStatus {
+    #[cfg(target_os = "windows")]
+    fn from(status: std::process::ExitStatus) -> Self {
+        Self {
+            code: status.code(),
+            signal: None,
+            success: status.success(),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn from(status: std::process::ExitStatus) -> Self {
+        use std::os::unix::process::ExitStatusExt;
+
+        Self {
+            code: status.code(),
+            signal: status.signal(),
+            success: status.success(),
+        }
+    }
+}

--- a/src/agent/onefuzz-supervisor/src/scheduler.rs
+++ b/src/agent/onefuzz-supervisor/src/scheduler.rs
@@ -7,7 +7,8 @@ use anyhow::Result;
 
 use crate::coordinator::NodeCommand;
 use crate::reboot::RebootContext;
-use crate::setup::{ISetupRunner, SetupOutput};
+use crate::process::Output;
+use crate::setup::ISetupRunner;
 use crate::work::*;
 use crate::worker::*;
 
@@ -81,11 +82,12 @@ pub struct Done {
     cause: DoneCause,
 }
 
+#[derive(Clone, Debug)]
 pub enum DoneCause {
     WorkersDone,
     SetupError {
         error: String,
-        script_output: SetupOutput,
+        script_output: Option<Output>,
     },
 }
 
@@ -258,7 +260,11 @@ impl From<Updated> for Scheduler {
     }
 }
 
-impl State<Done> {}
+impl State<Done> {
+    pub fn cause(&self) -> DoneCause {
+        self.ctx.cause.clone()
+    }
+}
 
 impl From<Option<RebootContext>> for Scheduler {
     fn from(ctx: Option<RebootContext>) -> Self {

--- a/src/agent/onefuzz-supervisor/src/scheduler.rs
+++ b/src/agent/onefuzz-supervisor/src/scheduler.rs
@@ -6,6 +6,7 @@ use std::fmt;
 use anyhow::Result;
 
 use crate::coordinator::NodeCommand;
+use crate::process::Output;
 use crate::reboot::RebootContext;
 use crate::setup::ISetupRunner;
 use crate::work::*;
@@ -77,7 +78,19 @@ pub struct Busy {
     workers: Vec<Option<Worker>>,
 }
 
-pub struct Done;
+pub struct Done {
+    cause: DoneCause,
+}
+
+pub enum DoneCause {
+    WorkersDone,
+    SetupError {
+        error: String,
+    },
+    SetupScriptError {
+        output: Output,
+    },
+}
 
 pub trait Context {}
 
@@ -186,7 +199,8 @@ impl State<Busy> {
         }
 
         let updated = if self.all_workers_done() {
-            Updated::Done(Done.into())
+            let done = Done { cause: DoneCause::WorkersDone };
+            Updated::Done(done.into())
         } else {
             Updated::Busy(self)
         };

--- a/src/agent/onefuzz-supervisor/src/scheduler.rs
+++ b/src/agent/onefuzz-supervisor/src/scheduler.rs
@@ -138,6 +138,7 @@ impl State<Free> {
 pub enum SetupDone {
     Ready(State<Ready>),
     PendingReboot(State<PendingReboot>),
+    Done(State<Done>),
 }
 
 impl State<SettingUp> {

--- a/src/agent/onefuzz-supervisor/src/scheduler.rs
+++ b/src/agent/onefuzz-supervisor/src/scheduler.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use crate::coordinator::NodeCommand;
 use crate::process::Output;
 use crate::reboot::RebootContext;
-use crate::setup::ISetupRunner;
+use crate::setup::{ISetupRunner, SetupOutput};
 use crate::work::*;
 use crate::worker::*;
 
@@ -86,9 +86,7 @@ pub enum DoneCause {
     WorkersDone,
     SetupError {
         error: String,
-    },
-    SetupScriptError {
-        output: Output,
+        script_output: SetupOutput,
     },
 }
 

--- a/src/agent/onefuzz-supervisor/src/scheduler.rs
+++ b/src/agent/onefuzz-supervisor/src/scheduler.rs
@@ -6,7 +6,6 @@ use std::fmt;
 use anyhow::Result;
 
 use crate::coordinator::NodeCommand;
-use crate::process::Output;
 use crate::reboot::RebootContext;
 use crate::setup::{ISetupRunner, SetupOutput};
 use crate::work::*;

--- a/src/agent/onefuzz-supervisor/src/setup.rs
+++ b/src/agent/onefuzz-supervisor/src/setup.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use std::path::{Path, PathBuf};
-use std::process::{Output, Stdio};
+use std::process::Stdio;
 
 use anyhow::Result;
 use downcast_rs::Downcast;
@@ -11,20 +11,23 @@ use onefuzz::blob::BlobContainerUrl;
 use tokio::fs;
 use tokio::process::Command;
 
+use crate::process::Output;
 use crate::work::*;
 
 const SETUP_PATH_ENV: &str = "ONEFUZZ_TARGET_SETUP_PATH";
 
+pub type SetupOutput = Option<Output>;
+
 #[async_trait]
 pub trait ISetupRunner: Downcast {
-    async fn run(&mut self, work_set: &WorkSet) -> Result<bool>;
+    async fn run(&mut self, work_set: &WorkSet) -> Result<SetupOutput>;
 }
 
 impl_downcast!(ISetupRunner);
 
 #[async_trait]
 impl ISetupRunner for SetupRunner {
-    async fn run(&mut self, work_set: &WorkSet) -> Result<bool> {
+    async fn run(&mut self, work_set: &WorkSet) -> Result<SetupOutput> {
         self.run(work_set).await
     }
 }
@@ -33,7 +36,7 @@ impl ISetupRunner for SetupRunner {
 pub struct SetupRunner;
 
 impl SetupRunner {
-    pub async fn run(&mut self, work_set: &WorkSet) -> Result<bool> {
+    pub async fn run(&mut self, work_set: &WorkSet) -> Result<SetupOutput> {
         info!("running setup for work set");
 
         // Download the setup container.
@@ -66,7 +69,7 @@ impl SetupRunner {
         // Run setup script, if any.
         let setup_script = SetupScript::new(setup_dir).await?;
 
-        if let Some(setup_script) = setup_script {
+        let output = if let Some(setup_script) = setup_script {
             info!(
                 "running setup script from {}",
                 setup_script.path().display()
@@ -75,31 +78,33 @@ impl SetupRunner {
             let output = setup_script.invoke().await?;
 
             info!(
-                "setup script run; status = {}, path = {}",
-                output.status,
+                "setup script run; exit_status = {:?}, path = {}",
+                output.exit_status,
                 setup_script.path().display(),
             );
 
-            if output.status.success() {
+            if output.exit_status.success {
                 verbose!(
                     "setup script succeeded:\nstdout = {}\nstderr = {}",
-                    String::from_utf8_lossy(&output.stdout),
-                    String::from_utf8_lossy(&output.stderr),
+                    &output.stdout,
+                    &output.stderr,
                 );
                 info!("setup script succeeded");
             } else {
                 error!(
                     "setup script failed:\nstdout = {}\nstderr = {}",
-                    String::from_utf8_lossy(&output.stdout),
-                    String::from_utf8_lossy(&output.stderr),
+                    &output.stdout, &output.stderr,
                 );
-                anyhow::bail!("setup script failed:\nstdout = {}\nstderr = {}");
             }
+
+            Some(output)
         } else {
             info!("no setup script to run");
-        }
 
-        Ok(work_set.reboot)
+            None
+        };
+
+        Ok(output)
     }
 }
 
@@ -178,7 +183,7 @@ impl SetupScript {
     }
 
     pub async fn invoke(&self) -> Result<Output> {
-        Ok(self.setup_command().output().await?)
+        Ok(self.setup_command().output().await?.into())
     }
 
     #[cfg(target_os = "windows")]

--- a/src/agent/onefuzz-supervisor/src/setup/double.rs
+++ b/src/agent/onefuzz-supervisor/src/setup/double.rs
@@ -6,13 +6,13 @@ use super::*;
 #[derive(Clone, Debug, Default)]
 pub struct SetupRunnerDouble {
     pub ran: Vec<WorkSet>,
-    pub script: bool,
+    pub script: SetupOutput,
 }
 
 #[async_trait]
 impl ISetupRunner for SetupRunnerDouble {
-    async fn run(&mut self, work_set: &WorkSet) -> Result<bool> {
+    async fn run(&mut self, work_set: &WorkSet) -> Result<SetupOutput> {
         self.ran.push(work_set.clone());
-        Ok(self.script)
+        Ok(self.script.clone())
     }
 }

--- a/src/agent/onefuzz-supervisor/src/worker.rs
+++ b/src/agent/onefuzz-supervisor/src/worker.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use downcast_rs::Downcast;
 use tokio::fs;
 
+use crate::process::*;
 use crate::work::*;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -21,44 +22,6 @@ pub enum WorkerEvent {
         stderr: String,
         stdout: String,
     },
-}
-
-/// Serializable representation of a worker process output.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct Output {
-    pub exit_status: ExitStatus,
-    pub stderr: String,
-    pub stdout: String,
-}
-
-/// Serializable representation of a worker exit status.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct ExitStatus {
-    pub code: Option<i32>,
-    pub signal: Option<i32>,
-    pub success: bool,
-}
-
-impl From<std::process::ExitStatus> for ExitStatus {
-    #[cfg(target_os = "windows")]
-    fn from(status: std::process::ExitStatus) -> Self {
-        Self {
-            code: status.code(),
-            signal: None,
-            success: status.success(),
-        }
-    }
-
-    #[cfg(target_os = "linux")]
-    fn from(status: std::process::ExitStatus) -> Self {
-        use std::os::unix::process::ExitStatusExt;
-
-        Self {
-            code: status.code(),
-            signal: status.signal(),
-            success: status.success(),
-        }
-    }
 }
 
 pub enum Worker {


### PR DESCRIPTION
## Summary of the Pull Request

When target setup fails, due to IO or a script, transition to an enriched `Done` scheduler state, rather than terminating the agent.

**NOTE:** based on pending branch, retarget before final review.

## PR Checklist
* [x] Applies to work item: #13 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/onefuzz) and sign the CLI.
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

## Validation Steps Performed

- [ ] Create a job with a setup script that intentionally exits nonzero. The agent should emit a `Done` event. Task and job state should be updated. Node should be automatically reimaged.